### PR TITLE
fix declaration name

### DIFF
--- a/language.rst
+++ b/language.rst
@@ -1445,7 +1445,7 @@ this one anonymous
 
     module Prod64s = Sum({
       type t = 64
-      let (x: f64) (y: f64): f64 = x * y
+      let add (x: f64) (y: f64): f64 = x * y
       let zero: f64 = 1.0
     })
 


### PR DESCRIPTION
Isn't the declaration name needed here for the anonymous module to satisfy the `Monoid` type module?