### PR TITLE
Typo fixes in 5.6

### DIFF
--- a/parallel-cost-model.rst
+++ b/parallel-cost-model.rst
@@ -538,7 +538,7 @@ contraction step until the array is sorted (i.e., when the contraction
 step has been executed for all bits.) To appreciate the purpose of
 each data-parallel operation in the function, the table below
 illustrates how ``rsort_step`` takes care of moving elements with a
-particular bit set (bit 2) to the end of the array. The example
+particular bit set (bit 1) to the end of the array. The example
 assumes the current array (``xs``) contains the array
 ``[2,0,6,4,2,1,5,9]``.  Notice that the last three values all have
 their 0-bit set whereas the first five values have not.

--- a/parallel-cost-model.rst
+++ b/parallel-cost-model.rst
@@ -546,7 +546,7 @@ their 0-bit set whereas the first five values have not.
 .. csv-table::
    :header: "Variable"
 
-   ``xs``, :math:`2^\dagger`, 0, :math:`2^\dagger`, 4, :math:`2^\dagger`, 1, 5, 9
+   ``xs``, 2, 0, 2, 4, 2, 1, 5, 9
    ``bits1``, 1, 0, 1, 0, 1, 0, 0, 0
    ``bits0``, 0, 1, 0, 1, 0, 1, 1, 1
    ``scan (+) 0 bits0``, 0, 1, 1, 2, 2, 3, 4, 5


### PR DESCRIPTION
I believe there were some errors in this section. Please take a look at the edits to see if you agree.