### PR TITLE
Revert "Remove unused bool operation, add note about extra accumulato…

### DIFF
--- a/regular-flattening.rst
+++ b/regular-flattening.rst
@@ -41,9 +41,6 @@ addition:
 .. literalinclude:: src/sgm_streak.fut
    :lines: 1-8
 
-Note that we have to include the extra boolean in the accumulator to satisfy the
-type signature of ``scan``.
-
 We can make use of Futhark's support for higher-order functions and
 polymorphism to define a generic version of segmented scan that will
 work for other monoidal structures than addition on ``i32`` values:

--- a/src/segmented.fut
+++ b/src/segmented.fut
@@ -5,12 +5,12 @@
 -- segments of ``as`` specified by the ``flags`` array, where `true`
 -- starts a segment and `false` continues a segment.
 let segmented_scan 't [n] (g:t->t->t) (ne: t) (flags: [n]bool) (vals: [n]t): [n]t =
-  let pairs = scan ( \ (v1,_) (v2,f2) ->
+  let pairs = scan ( \ (v1,f1) (v2,f2) ->
+                       let f = f1 || f2
                        let v = if f2 then v2 else g v1 v2
-                       in (v,false) ) (ne,false) (zip vals flags)
+                       in (v,f) ) (ne,false) (zip vals flags)
   let (res,_) = unzip pairs
   in res
-
 
 -- | Segmented reduction. Given a binary associative operator ``op``
 -- with neutral element ``ne``, computes the reduction of the segments

--- a/src/sgm_streak.fut
+++ b/src/sgm_streak.fut
@@ -1,11 +1,11 @@
 -- Segmented scan with integer addition
 let segmented_scan_add [n] (flags:[n]bool) (vals:[n]i32) : [n]i32 =
-  let pairs = scan ( \(v1,_) (v2,f2) ->
+  let pairs = scan ( \(v1,f1) (v2,f2) ->
+                       let f = f1 || f2
                        let v = if f2 then v2 else v1+v2
-                       in (v,false) ) (0,false) (zip vals flags)
+                       in (v,f) ) (0,false) (zip vals flags)
   let (res,_) = unzip pairs
   in res
-
 
 -- ==
 -- entry: segmented_scan_add_tester


### PR DESCRIPTION
…r var"

This reverts commit 2ad7b7b915efc3c895157d69ce36a25eedf6a57f.

I mistakenly intuited that it wasn't necessary to compute the disjunction of the
flags and pass them on. @coancea pointed out that the `scan` operation is
parallel, and that the disjuncted flag will be passed on and used in subsequent
calls to the function. In other words, the `scan` isn't a `scanl`...