### PR TITLE
Update type annotation in modules section

### DIFF
--- a/language.rst
+++ b/language.rst
@@ -1731,7 +1731,7 @@ module type:
 
 ::
 
-    module bar = add_i32 : { type t = int
+    module bar = add_i32 : { type t = i32
                              val zero : t }
 
 An attempt to access ``bar.add`` will result in a compilation error,


### PR DESCRIPTION
The modules section has the example

```
module bar = add_i32 : { type t = int
                         val zero : t }
```

Modify the `type t = int` to `type t = i32`.