### PR TITLE
Mention earlier that file must be `matmul.fut` in testing example

### DIFF
--- a/practical-matters.rst
+++ b/practical-matters.rst
@@ -44,7 +44,8 @@ after are taken as a description of a test to perform.  When
 for test blocks and perform the tests they describe.
 
 As an example, let us consider how to test a function for matrix
-multiplication.  The function itself is defined as thus:
+multiplication.  Suppose that we have the following defined in a file
+``matmul.fut``:
 
 .. literalinclude:: src/matmul.fut
    :lines: 17-20


### PR DESCRIPTION
In the first example in section 3.1.1, the file must be named
`matmul.fut` because it does a

```
-- input { [[1, 2]] [[3]] }
-- error: matmul.fut
```

later. Mention that before the first snippet (when the following-along
reader is first creating the file).