### PR TITLE
Fix typo in the array version of Fibonacci

### DIFF
--- a/language.rst
+++ b/language.rst
@@ -1422,7 +1422,7 @@ first Fibonacci numbers:
 
     let fib (n: i32): []i32 =
       -- Create "empty" array.
-      let arr = replicate n 0
+      let arr = replicate n 1
       -- Fill array with Fibonacci numbers.
       in loop (arr) for i < n-2 do
            arr with [i+2] = arr[i] + arr[i+1]


### PR DESCRIPTION
Right now the function produces a list of zeroes.