### PR TITLE
Fix Non-lifted type compilation error

### DIFF
--- a/interoperability.rst
+++ b/interoperability.rst
@@ -331,7 +331,7 @@ by the previous call is the only way to accomplish this.  Fortunately,
 we can assign these opaque types somewhat more readable names by type
 abbreviations::
 
-  type array_of_pairs = [](i32,i32)
+  type~ array_of_pairs = [](i32,i32)
 
   entry pack (xs: []i32) (ys: []i32): array_of_pairs = zip xs ys
 


### PR DESCRIPTION
The program
```
  type array_of_pairs = [](i32,i32)

  entry pack (xs: []i32) (ys: []i32): array_of_pairs = zip xs ys

  entry unpack (zs: array_of_pairs): ([]i32,[]i32) = unzip zs
```
gives an error when compiled with `futhark c --lib pack.fut`
```
Error at pack1.fut:1:1-33:
Non-lifted type abbreviations may not use anonymous sizes in their definition.
Hint: use 'type~' or add size parameters to "array_of_pairs".

If you find this error message confusing, uninformative, or wrong, please open an issue at
https://github.com/diku-dk/futhark/issues.
```
This PR changes `type` to `type~` to that the program can be compiled and works as expected


