### PR TITLE
Fix math color scoping for MathJax 3

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -29,8 +29,8 @@
 \newcommand{\id}[1]{\textit{#1}}
 \newcommand{\rarr}{\rightarrow}
 \newcommand{\larr}{\leftarrow}
-\newcommand{\fop}[1]{\color{blue}{\texttt{#1}}}
-\newcommand{\fw}[1]{\color{green}{\texttt{#1}}}
+\newcommand{\fop}[1]{\textcolor{blue}{\texttt{#1}}}
+\newcommand{\fw}[1]{\textcolor{green}{\texttt{#1}}}
 \newcommand{\Eval}[1]{\sem{\,#1\,}}
 \newcommand{\extractF}[1]{\langle\,#1\,\rangle}
 \newcommand{\Let}{\mathrm{let}}


### PR DESCRIPTION
This fixes math color scoping, which I noticed seemed to be running on for the rest of each expression when it appeared:

<img width="630" height="29" alt="image" src="https://github.com/user-attachments/assets/84165967-7d97-486a-8e37-30b04c97a7ed" />

With this change, the expected result is restored:

<img width="630" height="29" alt="image" src="https://github.com/user-attachments/assets/aa9d05c3-720c-45e9-b7d4-f52309426ed2" />

It appears the coloring regressed with https://github.com/diku-dk/futhark-book/commit/cecc59d3b7a669d3e009f0448300c5f9a427487e, which happened to upgrade Sphinx from 1.8.5 to 4.2.0. Sphinx 4 [changed](https://www.sphinx-doc.org/en/master/changes/4.0.html#release-4-0-0-released-may-09-2021) its MathJax major version from 2 to 3. In MathJax 3, the semantics of the LaTeX `\color` command [changed](https://docs.mathjax.org/en/latest/input/tex/extensions/color.html) to a switch that leaves the color active until changed again (instead of scoped block), matching the LaTeX `\color` semantics.

This restores the expected coloring by using the `\textcolor` LaTeX command instead, which includes the expected color scoping.